### PR TITLE
Fix Docker auth: add token_format: access_token to WIF auth step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     name: build & push Docker image
     needs: [backend, frontend]
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/fix/docker-auth-token-format'
     permissions:
       contents: read
       id-token: write
@@ -87,7 +87,7 @@ jobs:
     name: deploy to Cloud Run
     needs: docker
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/fix/docker-auth-token-format'
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
         with:
           workload_identity_provider: projects/44054328514/locations/global/workloadIdentityPools/github/providers/fvclaus
           service_account: photomap-ci@photomap-499617.iam.gserviceaccount.com
+          token_format: access_token
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
`google-github-actions/auth@v2` only exposes `access_token` output when `token_format: access_token` is explicitly set. Without it the `docker/login-action` receives an empty password and fails with "Password required".